### PR TITLE
#7: Set default phone to undefined.

### DIFF
--- a/src/CallControl/CallControl.ts
+++ b/src/CallControl/CallControl.ts
@@ -161,7 +161,7 @@ export class CallControl extends EventEmitter {
     }
 
     public answer(channel: Channel, phone?: string): void {
-        this.sendAction(new AnswerAction(channel.getCallID(), phone ? phone : channel.getPhoneID()));
+        this.sendAction(new AnswerAction(channel.getCallID(), phone));
     }
 
     public bridge(callID: string, otherCallID: string, channelToBridge?: Channel, otherChannelToBridge?: Channel): void {


### PR DESCRIPTION
This means the backend will fall back to the call control setting. It was picking the phone from the channel.